### PR TITLE
Use configuration for secrets and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ http://localhost:3000/
 ```
 
 
+### Configuration
+
+The applications rely on a few configuration values:
+
+- **AuthWebApplication** expects a JWT secret in configuration: `Jwt:Secret`.
+- **React client** reads API endpoints from environment variables:
+  - `REACT_APP_API_BASE` – base URL for resource API calls.
+  - `REACT_APP_AUTH_URL` – base URL for authentication API calls.
+
+You can copy `client/.env.sample` to `client/.env` and adjust the values as needed.
+
 ### How to run video
 
 React Redux JWT Authentication using ASP.NET Core API

--- a/client/.env.sample
+++ b/client/.env.sample
@@ -1,0 +1,2 @@
+REACT_APP_API_BASE=https://localhost:5003/api
+REACT_APP_AUTH_URL=https://localhost:5001

--- a/client/src/sagas/api.js
+++ b/client/src/sagas/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-const BaseUrl = 'https://localhost:5003/api';
-const AuthUrl = 'https://localhost:5001';
+const BaseUrl = process.env.REACT_APP_API_BASE || 'https://localhost:5003/api';
+const AuthUrl = process.env.REACT_APP_AUTH_URL || 'https://localhost:5001';
 
 
 axios.interceptors.request.use(function (config) {

--- a/server/AuthWebApplication/AuthWebApplication/Startup.cs
+++ b/server/AuthWebApplication/AuthWebApplication/Startup.cs
@@ -24,12 +24,13 @@ namespace AuthWebApplication
     public class Startup
     {
         const string BizBook365Com = "bizbook365.com";
-        private const string SecretKey = "a55ae165-912d-4052-b61e-aeeb6d6d2c07";
-        private readonly SymmetricSecurityKey SigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(SecretKey));
+        private readonly SymmetricSecurityKey SigningKey;
 
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
+            var secretKey = Configuration["Jwt:Secret"];
+            SigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(secretKey));
         }
 
         public IConfiguration Configuration { get; }

--- a/server/AuthWebApplication/AuthWebApplication/appsettings.json
+++ b/server/AuthWebApplication/AuthWebApplication/appsettings.json
@@ -14,5 +14,8 @@
   "Redis": {
     "Host": "localhost",
     "Port": "6379"
+  },
+  "Jwt": {
+    "Secret": "a55ae165-912d-4052-b61e-aeeb6d6d2c07"
   }
 }


### PR DESCRIPTION
## Summary
- load JWT signing key from configuration
- read API endpoints from environment variables in client
- document required configuration and provide sample `.env`

## Testing
- `dotnet build server/AuthWebApplication/AuthWebApplication.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test --prefix client -- --watchAll=false` *(fails: could not find react-redux context value)*

------
https://chatgpt.com/codex/tasks/task_e_68a50c6ff18483249f32375fef2f0cdc